### PR TITLE
Align house style: SHA-pin publish action, simplify CI, add py.typed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
           enable-cache: true
       - name: Set up Python ${{ matrix.python-version }}
         run: uv python install ${{ matrix.python-version }}
+      - name: Sync dependencies
+        run: uv sync --python ${{ matrix.python-version }}
       - name: Run unit tests with coverage
-        run: uv run --python ${{ matrix.python-version }} --with pytest --with pytest-cov --with pyyaml --with typer --with httpx --with rich --with click --with tomli-w --with python-dotenv pytest tests/ -m "not integration" -v --cov=openapi_cli4ai --cov-report=term-missing
+        run: uv run --python ${{ matrix.python-version }} pytest tests/ -m "not integration" -v --cov=openapi_cli4ai --cov-report=term-missing
 
   lint:
     runs-on: ubuntu-latest
@@ -40,5 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - uses: astral-sh/setup-uv@cec208311dfd045dd5311c1add060b2062131d57 # v8.0.0
+      - name: Sync dependencies
+        run: uv sync
       - name: Run mypy
-        run: uv run --with mypy --with types-PyYAML --with pyyaml --with typer --with httpx --with rich --with click --with tomli-w --with python-dotenv mypy src/openapi_cli4ai/ --ignore-missing-imports
+        run: uv run mypy src/openapi_cli4ai/ --ignore-missing-imports

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -46,4 +46,4 @@ jobs:
         with:
           subject-path: dist/*
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,14 @@ Issues = "https://github.com/dbgorilla/openapi-cli4ai/issues"
 [project.scripts]
 openapi-cli4ai = "openapi_cli4ai.cli:app"
 
+[dependency-groups]
+dev = [
+    "pytest>=8",
+    "pytest-cov>=5",
+    "mypy>=1.10,<2",
+    "types-PyYAML>=6,<7",
+]
+
 [tool.hatch.build.targets.wheel]
 packages = ["src/openapi_cli4ai"]
 


### PR DESCRIPTION
## Summary

Three small hardening / consistency changes surfaced while aligning `dbg-a2a-comms` with this repo's style.

- **SHA-pin `pypa/gh-action-pypi-publish`** — `publish.yml` was using the moving `@release/v1` tag. `SECURITY.md` claims "All GitHub Actions pinned to commit SHAs," so this was a drift and a tag-hijack risk. Pinned to `cef2210` (v1.14.0).
- **Move dev deps to `[dependency-groups]`** — `ci.yml` previously inlined every dev dep via `uv run --with pytest --with pytest-cov --with pyyaml --with typer ...`. Adding a dev dep required editing both `pyproject.toml` and `ci.yml`, with nothing enforcing consistency. Now `pyproject.toml` owns the dev-group list and CI runs `uv sync` then `uv run pytest` / `uv run mypy`. One source of truth.
- **Add `py.typed` marker** — signals PEP 561 compliance so downstream users' type checkers see our inline hints.

No functional change to tests, typecheck, or published-package behavior.

## Test plan

- [x] `uv sync` produces a clean lock with the new dev group
- [x] `uv run pytest tests/ -m "not integration"` — 488 passed, 27 deselected
- [x] `uvx ruff check .` — clean
- [x] `uvx ruff format --check .` — clean
- [x] `uv run mypy src/openapi_cli4ai/ --ignore-missing-imports` — clean
- [ ] CI green on this branch