### PR TITLE
fix: YAML spec ingestion (vnd.oai.openapi) + version reporting — surfaced by Codecov

### DIFF
--- a/src/openapi_cli4ai/cli.py
+++ b/src/openapi_cli4ai/cli.py
@@ -458,11 +458,22 @@ def fetch_spec(profile: dict, refresh: bool = False) -> dict:
                 f"Got HTML instead of OpenAPI spec from {spec_url} — the server may have a frontend catch-all route"
             )
 
-        # Handle JSON or YAML
-        if "yaml" in content_type or spec_url.endswith((".yaml", ".yml")):
+        # Handle JSON or YAML. Some servers serve a YAML spec under a
+        # non-obvious media type — e.g. Codecov's schema endpoint returns
+        # "application/vnd.oai.openapi" (the standard OpenAPI YAML type),
+        # which contains neither "yaml" nor a ".yaml" suffix. Prefer JSON
+        # when the type says so (covers the "+json" variant), route known
+        # YAML types to the YAML parser, and fall back to YAML if a body
+        # not advertised as JSON fails to decode.
+        ct = content_type.lower()
+        is_yaml = "yaml" in ct or "vnd.oai.openapi" in ct or spec_url.endswith((".yaml", ".yml"))
+        if is_yaml and "json" not in ct:
             spec = yaml.safe_load(resp.text)
         else:
-            spec = resp.json()
+            try:
+                spec = resp.json()
+            except json.JSONDecodeError:
+                spec = yaml.safe_load(resp.text)
 
         # Write cache atomically to prevent partial writes
         ensure_dirs()

--- a/src/openapi_cli4ai/cli.py
+++ b/src/openapi_cli4ai/cli.py
@@ -26,6 +26,7 @@ import base64
 import binascii
 from email.utils import parsedate_to_datetime
 import hashlib
+from importlib.metadata import version as _pkg_version, PackageNotFoundError
 import html as html_module  # noqa: F401 (used by F3: OIDC callback HTML escaping)
 import json
 import os
@@ -56,8 +57,11 @@ from rich.panel import Panel  # noqa: E402
 from rich.table import Table  # noqa: E402
 
 # ── Constants ──────────────────────────────────────────────────────────────────
-VERSION = "0.4.0"
 APP_NAME = "openapi-cli4ai"
+try:
+    VERSION = _pkg_version(APP_NAME)
+except PackageNotFoundError:  # running from a source checkout without an install
+    VERSION = "0.0.0+dev"
 CONFIG_FILE = Path.home() / ".openapi-cli4ai.toml"
 CACHE_DIR = Path.home() / ".cache" / APP_NAME
 CACHE_TTL = 3600  # 1 hour

--- a/tests/test_caching.py
+++ b/tests/test_caching.py
@@ -105,3 +105,81 @@ def test_fetch_spec_stale_cache_triggers_fetch(tmp_config, petstore_spec):
         mock_make_client.return_value = mock_ctx
         result = mod.fetch_spec(profile)
         assert result["info"]["title"] == petstore_spec["info"]["title"]
+
+
+def _fetch_with_mocked_response(mod, profile, response):
+    """Run fetch_spec with _make_client mocked to return `response` from a fresh fetch."""
+    # raise_for_status() needs a request attached to the response.
+    response.request = httpx.Request("GET", profile.get("openapi_url", profile["base_url"]))
+    mock_client = MagicMock()
+    mock_client.get = MagicMock(return_value=response)
+    mock_ctx = MagicMock()
+    mock_ctx.__enter__ = MagicMock(return_value=mock_client)
+    mock_ctx.__exit__ = MagicMock(return_value=False)
+    with patch("openapi_cli4ai.cli._make_client", return_value=mock_ctx):
+        return mod.fetch_spec(profile)
+
+
+def test_fetch_spec_parses_yaml_vnd_oai_media_type(tmp_config):
+    """Should parse a YAML spec served as application/vnd.oai.openapi (e.g. Codecov)."""
+    mod, _config_dir, _cache_dir = tmp_config
+    profile = {
+        "base_url": "https://api.codecov.io/api/v2",
+        "openapi_url": "https://api.codecov.io/api/v2/schema/",
+        "auth": {"type": "none"},
+        "verify_ssl": True,
+        "_name": "codecov",
+    }
+    yaml_spec = (
+        "openapi: 3.0.3\n"
+        "info:\n  title: Codecov API\n  version: 2.0.0\n"
+        "paths:\n  /repos/:\n    get:\n      summary: List repos\n"
+    )
+    response = httpx.Response(
+        200,
+        content=yaml_spec.encode(),
+        headers={"content-type": "application/vnd.oai.openapi; charset=utf-8"},
+    )
+    spec = _fetch_with_mocked_response(mod, profile, response)
+    assert spec["info"]["title"] == "Codecov API"
+    assert "/repos/" in spec["paths"]
+
+
+def test_fetch_spec_falls_back_to_yaml_on_mislabeled_json(tmp_config):
+    """Should fall back to YAML when a body advertised as JSON is actually YAML."""
+    mod, _config_dir, _cache_dir = tmp_config
+    profile = {
+        "base_url": "https://example.com",
+        "openapi_url": "https://example.com/schema",
+        "auth": {"type": "none"},
+        "verify_ssl": True,
+        "_name": "mislabeled",
+    }
+    yaml_spec = "openapi: 3.0.3\ninfo:\n  title: Mislabeled\n  version: 1.0.0\npaths: {}\n"
+    response = httpx.Response(
+        200,
+        content=yaml_spec.encode(),
+        headers={"content-type": "application/json"},  # server lies
+    )
+    spec = _fetch_with_mocked_response(mod, profile, response)
+    assert spec["info"]["title"] == "Mislabeled"
+
+
+def test_fetch_spec_parses_vnd_oai_openapi_json_variant(tmp_config):
+    """The +json variant should still parse via the JSON path."""
+    mod, _config_dir, _cache_dir = tmp_config
+    profile = {
+        "base_url": "https://api.codecov.io/api/v2",
+        "openapi_url": "https://api.codecov.io/api/v2/schema/?format=json",
+        "auth": {"type": "none"},
+        "verify_ssl": True,
+        "_name": "codecovjson",
+    }
+    json_spec = json.dumps({"openapi": "3.0.3", "info": {"title": "Codecov API", "version": "2.0.0"}, "paths": {}})
+    response = httpx.Response(
+        200,
+        content=json_spec.encode(),
+        headers={"content-type": "application/vnd.oai.openapi+json"},
+    )
+    spec = _fetch_with_mocked_response(mod, profile, response)
+    assert spec["info"]["title"] == "Codecov API"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1210,6 +1210,12 @@ class TestMainCallback:
         assert "openapi-cli4ai" in result.output
         assert mod.VERSION in result.output
 
+    def test_version_derived_from_package_metadata(self, cli_module):
+        """VERSION comes from installed package metadata, not a hardcoded literal."""
+        from importlib.metadata import version
+
+        assert cli_module.VERSION == version("openapi-cli4ai")
+
     def test_no_subcommand_shows_help(self, tmp_config):
         mod, tmp_path, cache_dir = tmp_config
 


### PR DESCRIPTION
Two correctness bugs surfaced while dogfooding the CLI against Codecov's API.

## 1. YAML OpenAPI spec ingestion (the reported issue)
Pointing at Codecov's spec (`…/api/v2/schema/`) failed — `Expecting value: line 1 column 1`, **0 endpoints**. Codecov serves its spec as **YAML** under the standard OpenAPI media type `application/vnd.oai.openapi`, which `fetch_spec` didn't recognize (no `yaml` substring, URL ends `/schema/`), so it fell through to `resp.json()`.

**Fix:** detect known YAML media types (incl. `application/vnd.oai.openapi`), prefer JSON when the type says so (covers the `+json` variant), and fall back to YAML when a non-JSON body fails to decode. PyYAML already a dependency. Dogfooded: Codecov's default schema URL now loads **35 endpoints**.

## 2. Stale hardcoded version
`cli.py` hardcoded `VERSION = "0.4.0"` and it was never bumped at the 0.5.0 release, so `--version` misreported and would drift every release. Now derived from `importlib.metadata.version()` with a source-checkout fallback.

## Verification
- Installed the built CLI (`uv tool install`): loads Codecov's YAML spec (35 endpoints); `--version` now reports 0.5.0.
- 4 new tests (3 spec-ingestion, 1 version-metadata). Full suite: **492 passed**.