### PR TITLE
test: add Xquik profile example

### DIFF
--- a/examples/xquik.profile.toml.example
+++ b/examples/xquik.profile.toml.example
@@ -1,0 +1,13 @@
+# Xquik REST API profile for openapi-cli4ai
+# Set XQUIK_API_KEY before calling authenticated endpoints.
+
+active_profile = "xquik"
+
+[profiles.xquik]
+base_url = "https://xquik.com"
+openapi_url = "https://xquik.com/openapi.json"
+
+[profiles.xquik.auth]
+type = "api-key"
+env_var = "XQUIK_API_KEY"
+header = "x-api-key"

--- a/tests/test_xquik_profile_example.py
+++ b/tests/test_xquik_profile_example.py
@@ -1,0 +1,24 @@
+from pathlib import Path
+
+try:
+    import tomllib
+except ModuleNotFoundError:
+    import tomli as tomllib
+
+
+def test_xquik_profile_example_is_valid_toml() -> None:
+    example_path = (
+        Path(__file__).resolve().parents[1] / "examples" / "xquik.profile.toml.example"
+    )
+
+    data = tomllib.loads(example_path.read_text(encoding="utf-8"))
+
+    assert data["active_profile"] == "xquik"
+    profile = data["profiles"]["xquik"]
+    assert profile["base_url"] == "https://xquik.com"
+    assert profile["openapi_url"] == "https://xquik.com/openapi.json"
+    assert profile["auth"] == {
+        "type": "api-key",
+        "env_var": "XQUIK_API_KEY",
+        "header": "x-api-key",
+    }


### PR DESCRIPTION
## Summary

- Add a standalone Xquik profile example for the public OpenAPI document.
- Keep credentials local by referencing `XQUIK_API_KEY` and the `x-api-key` header.
- Add a parser test so the example stays valid TOML.

## Validation

- `python3 -m compileall tests/test_xquik_profile_example.py`
- `uv run pytest tests/test_xquik_profile_example.py -q`