### PR TITLE
Release 0.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
+## [0.5.1] - 2026-07-04
+
+### Fixed
+
+- Ingest YAML OpenAPI specs served as `application/vnd.oai.openapi` (e.g. Codecov's schema endpoint), with a YAML fallback when a body advertised as JSON fails to decode (#22)
+- `--version` now derives from installed package metadata instead of a hardcoded literal that had drifted from the real version (#22)
+
+### Changed
+
+- Commit `uv.lock` and use `uv sync --locked` in CI for reproducible builds; Dependabot now updates the lockfile via the `uv` ecosystem (#20)
+- Dependency updates: `typer` 0.26 (with test adjustments for its vendored `click`), plus the python-deps and GitHub Actions groups (#21, #19, #16)
+
 ## [0.5.0] - 2026-04-21
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openapi-cli4ai"
-version = "0.5.0"
+version = "0.5.1"
 description = "Turn any REST API with an OpenAPI spec into an AI-ready CLI"
 readme = "README.md"
 license = "MIT"

--- a/uv.lock
+++ b/uv.lock
@@ -416,7 +416,7 @@ wheels = [
 
 [[package]]
 name = "openapi-cli4ai"
-version = "0.5.0"
+version = "0.5.1"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
Bug-fix release. Bumps `pyproject` + `uv.lock` to **0.5.1** and adds the CHANGELOG entry.

**Since 0.5.0:**
- fix: ingest YAML OpenAPI specs (`application/vnd.oai.openapi`, e.g. Codecov) (#22)
- fix: `--version` derived from package metadata, no longer a stale literal (#22)
- ci: commit `uv.lock`, `uv sync --locked`, Dependabot on the `uv` ecosystem (#20)
- deps: typer 0.26 (+ test adjustments for vendored click), python-deps & actions groups (#21, #19, #16)

Merging this, then I'll cut the `v0.5.1` GitHub release to trigger the PyPI publish.